### PR TITLE
Remove trailing comma; JSON not allowed trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Here's an example request:
     "jsonrpc": "2.0",
     "method": "+",
     "params": [1, 2, 3],
-    "id": 29492,
+    "id": 29492
 }
 ```
 


### PR DESCRIPTION
Hi, I found README issue, I fixit.

Remove trailing comma; JSON not allowed trailing commas.